### PR TITLE
RAIL-10: Rendering Decoded messages in the UI

### DIFF
--- a/lib/railway_ui_web/templates/consumed_message/index.html.eex
+++ b/lib/railway_ui_web/templates/consumed_message/index.html.eex
@@ -1,29 +1,28 @@
 <div class="row justify-content-md-center">
   <div class="col-md-auto">
-    <h1 class="display-3">Consumed Messages
-    </h1>
-    <table class="table table-responsive pt-3 table-hover">
-      <thead>
+    <h1 class="display-3">Consumed Messages</h1>
+    <table class="table table-bordered table-responsive table-hover">
+      <thead class="thead-dark">
         <tr>
-          <th>Message Type</th>
-          <th>UUID</th>
-          <th>Correlation ID</th>
-          <th>User UUID</th>
-          <th>Queue</th>
-          <th>Exchange</th>
-          <th>Encoded Message</th>
+          <th scope="col">Encoded Message</th>
+          <th scope="col">Message Type</th>
+          <th scope="col">UUID</th>
+          <th scope="col">Correlation ID</th>
+          <th scope="col">User UUID</th>
+          <th scope="col">Queue</th>
+          <th scope="col">Exchange</th>
         </tr>
       </thead>
       <tbody>
         <%= for message <- @messages do %>
-          <tr>
+          <tr class="table-active">
+            <td><pre><%= decode_message_body(message) %></pre></td>
             <td><%= message.message_type %></td>
             <td><%= message.uuid %></td>
             <td><%= message.correlation_id %></td>
             <td><%= message.user_uuid %></td>
             <td><%= message.queue %></td>
             <td><%= message.exchange %></td>
-            <td><%= decode_message_body(message.encoded_message) %></td>
           </tr>
         <% end %>
       </tbody>

--- a/lib/railway_ui_web/templates/consumed_message/index.html.eex
+++ b/lib/railway_ui_web/templates/consumed_message/index.html.eex
@@ -4,7 +4,7 @@
     <table class="table table-bordered table-responsive table-hover">
       <thead class="thead-dark">
         <tr>
-          <th scope="col">Encoded Message</th>
+          <th scope="col">Decoded Message</th>
           <th scope="col">Message Type</th>
           <th scope="col">UUID</th>
           <th scope="col">Correlation ID</th>

--- a/lib/railway_ui_web/templates/published_message/index.html.eex
+++ b/lib/railway_ui_web/templates/published_message/index.html.eex
@@ -1,35 +1,34 @@
 <div class="row justify-content-md-center">
   <div class="col-md-auto">
-    <h1 class="display-3">Published Messages
-    </h1>
-    <table class="table table-responsive pt-3 table-hover">
-      <thead>
+    <h1 class="display-3">Published Messages</h1>
+    <table class="table table-bordered table-responsive table-hover">
+      <thead class="thead-dark">
         <tr>
-          <th>Actions</th>
-          <th>Message Type</th>
-          <th>UUID</th>
-          <th>Correlation ID</th>
-          <th>User UUID</th>
-          <th>Queue</th>
-          <th>Exchange</th>
-          <th>Encoded Message</th>
+          <th scope="col">Actions</th>
+          <th scope="col">Encoded Message</th>
+          <th scope="col">Message Type</th>
+          <th scope="col">UUID</th>
+          <th scope="col">Correlation ID</th>
+          <th scope="col">User UUID</th>
+          <th scope="col">Queue</th>
+          <th scope="col">Exchange</th>
         </tr>
       </thead>
       <tbody>
         <%= for message <- @messages do %>
-          <tr>
+          <tr class="table-active">
             <%= if message.message_type != "RailwayIpc::Commands::RepublishMessage" do %>
               <td><%= link "republish", to: Routes.published_message_path(@conn, :republish, %{uuid: message.uuid}), method: :post, class: "btn btn-info" %></td>
             <% else %>
-              <td> <button type="button" name="button" class="btn btn-info" disabled>republish</button>  </td>
+              <td><button type="button" name="button" class="btn btn-info" disabled>republish</button></td>
             <% end %>
+            <td><pre><%= decode_message_body(message) %></pre></td>
             <td><%= message.message_type %></td>
             <td><%= message.uuid %></td>
             <td><%= message.correlation_id %></td>
             <td><%= message.user_uuid %></td>
             <td><%= message.queue %></td>
             <td><%= message.exchange %></td>
-            <td><%= decode_message_body(message.encoded_message) %></td>
           </tr>
         <% end %>
       </tbody>

--- a/lib/railway_ui_web/templates/published_message/index.html.eex
+++ b/lib/railway_ui_web/templates/published_message/index.html.eex
@@ -5,7 +5,7 @@
       <thead class="thead-dark">
         <tr>
           <th scope="col">Actions</th>
-          <th scope="col">Encoded Message</th>
+          <th scope="col">Decoded Message</th>
           <th scope="col">Message Type</th>
           <th scope="col">UUID</th>
           <th scope="col">Correlation ID</th>

--- a/lib/railway_ui_web/views/message_view_helper.ex
+++ b/lib/railway_ui_web/views/message_view_helper.ex
@@ -3,7 +3,7 @@ defmodule RailwayUiWeb.MessageViewHelper do
     %{"encoded_message" => message_to_decode} = Jason.decode!(encoded_message)
 
     try do
-      stuff = message_type
+      message_type
       |> RailwayIpc.Core.Payload.module_from_type()
       |> RailwayIpc.Core.Payload.decode_message(message_to_decode)
       |> inspect(pretty: true)

--- a/lib/railway_ui_web/views/message_view_helper.ex
+++ b/lib/railway_ui_web/views/message_view_helper.ex
@@ -1,5 +1,15 @@
 defmodule RailwayUiWeb.MessageViewHelper do
-  def decode_message_body(message_body) do
-    inspect(Jason.decode!(message_body))
+  def decode_message_body(%{message_type: message_type, encoded_message: encoded_message}) do
+    %{"encoded_message" => message_to_decode} = Jason.decode!(encoded_message)
+
+    try do
+      stuff = message_type
+      |> RailwayIpc.Core.Payload.module_from_type()
+      |> RailwayIpc.Core.Payload.decode_message(message_to_decode)
+      |> inspect(pretty: true)
+    rescue
+      UndefinedFunctionError -> "Unable to decode message due to missing message module"
+      error -> error
+    end
   end
 end

--- a/lib/railway_ui_web/views/message_view_helper.ex
+++ b/lib/railway_ui_web/views/message_view_helper.ex
@@ -2,14 +2,15 @@ defmodule RailwayUiWeb.MessageViewHelper do
   def decode_message_body(%{message_type: message_type, encoded_message: encoded_message}) do
     %{"encoded_message" => message_to_decode} = Jason.decode!(encoded_message)
 
-    try do
-      message_type
-      |> RailwayIpc.Core.Payload.module_from_type()
+    module = message_type
+    |> RailwayIpc.Core.Payload.module_from_type()
+
+    if Code.ensure_compiled?(module) do
+      module
       |> RailwayIpc.Core.Payload.decode_message(message_to_decode)
       |> inspect(pretty: true)
-    rescue
-      UndefinedFunctionError -> "Unable to decode message due to missing message module"
-      error -> error
+    else
+      "Unable to decode message due to missing message module!"
     end
   end
 end


### PR DESCRIPTION
# Description 

Changes:
1. Updated Published/Consumed Messages view with a human readable decoded message
2. Dark header to make table headers a bit more readable
3. Lightly shaded rows to make table look more like a table. 
4. Boarded table and columns.

Closes out [RAIL-10](https://flatiron.atlassian.net/browse/RAIL-10)

## New Look 

#### Published Messages

<img width="1207" alt="Screen Shot 2020-06-17 at 7 25 35 PM" src="https://user-images.githubusercontent.com/15013243/84971133-f054d900-b0d0-11ea-84d0-cc0d5db15348.png">
#### Consumed Messages

<img width="1240" alt="Screen Shot 2020-06-17 at 7 25 40 PM" src="https://user-images.githubusercontent.com/15013243/84971112-e632da80-b0d0-11ea-9c94-f8cc80f6fc2b.png">

## Old Look 

#### Published Messages

<img width="1242" alt="Screen Shot 2020-06-17 at 7 27 25 PM" src="https://user-images.githubusercontent.com/15013243/84971203-137f8880-b0d1-11ea-85c4-4fde19fa6e60.png">

#### Consumed Messages

<img width="1284" alt="Screen Shot 2020-06-17 at 7 27 31 PM" src="https://user-images.githubusercontent.com/15013243/84971172-06629980-b0d1-11ea-9d30-0194320d0082.png">
